### PR TITLE
Feature development

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -25,8 +25,9 @@ function openTestDialog()
 
 function populateGeneralInformation(form)
 {
-  console.log(typeof form);
-  console.log("for general information, form is " + form);
+  console.log("form's type is " + typeof form); // Debugs as object
+  console.log("form.id returns: " + form.id); // Debugs as undefined.
+  console.log("for general information, form is " + form); // Debugs as [object Object]
   var marker = ['{Test Plan Name}', '{Name}', '{Date}', '{Jira #}', '{Part name}', '{Part number}', '{Project name}'];
   var fieldName = [form.testPlanName, form.fullName, form.date, form.jiraTicketNumber, form.partName, form.partNumber, form.projectName]; // I learned that arrays can store a class with a property, like form.fullName. Arrays can store any data type!
   
@@ -45,15 +46,19 @@ function populateGeneralInformation(form)
 
 function populateTestSpecificInformation(form)
 {
-  console.log(typeof form);
+  console.log("form's type is " + typeof form); // Debugs as object, which matches populateGeneralInformation.
+  console.log("form.id returns: " + form.id); // Debugs as undefined. How can we get the id of the form?
+  console.log("for test specific information, form is " + form); // Debugs as [object Object]. Tried setting a case to [object Object] but got an error.
+  console.log("dwellTemp is " + form.dwellTemp + " and dwell time is " + form.dwellTime); // Debugs the typed value!!! 
   var marker = [];
   var fieldName = [];
-  //var id = form.id;
-  console.log("form is " + form.id);
+  /* TO DO: Right now the argument (the id) is being passed as a string. This causes the if statement error because the string isn't an object, so it
+  can't access the object's text boxes. Get the form's id as an object, 
+  then we can make cases for each form id that accept objects instead of strings. Can we convert the argument from string to object after it is passed in? */
   switch (form)
   {
     case "thermalCycleVariables":
-      alert("thermal cycle has been hit.")
+      console.log("thermal cycle has been hit.")
       marker = ['{minTemp}', '{maxTemp}', '{dwellTime}', '{cycles}'];
       fieldName = [form.minTemp, form.maxTemp, form.dwellTime, form.cycles]; 
       break;

--- a/Code.js
+++ b/Code.js
@@ -25,6 +25,8 @@ function openTestDialog()
 
 function populateGeneralInformation(form)
 {
+  console.log(typeof form);
+  console.log("for general information, form is " + form);
   var marker = ['{Test Plan Name}', '{Name}', '{Date}', '{Jira #}', '{Part name}', '{Part number}', '{Project name}'];
   var fieldName = [form.testPlanName, form.fullName, form.date, form.jiraTicketNumber, form.partName, form.partNumber, form.projectName]; // I learned that arrays can store a class with a property, like form.fullName. Arrays can store any data type!
   
@@ -41,13 +43,65 @@ function populateGeneralInformation(form)
   }
 }
 
-function addNewTest(form) {
+function populateTestSpecificInformation(form)
+{
+  console.log(typeof form);
+  var marker = [];
+  var fieldName = [];
+  //var id = form.id;
+  console.log("form is " + form.id);
+  switch (form)
+  {
+    case "thermalCycleVariables":
+      alert("thermal cycle has been hit.")
+      marker = ['{minTemp}', '{maxTemp}', '{dwellTime}', '{cycles}'];
+      fieldName = [form.minTemp, form.maxTemp, form.dwellTime, form.cycles]; 
+      break;
+    case "coldSoakVariables":
+      marker = ['{dwellTemp}', '{dwellTime}', '{minVoltage}', '{maxVoltage}'];
+      fieldName = [form.dwellTemp, form.dwellTime, form.minVoltage, form.maxVoltage];
+      break;
+    case "hotSoakVariables":
+      marker = ['{dwellTemp}', '{dwellTime}', '{minVoltage}', '{maxVoltage}', '{steadyTime}', '{voltageRange}'];
+      fieldName = [form.dwellTemp, form.dwellTime, form.minVoltage, form.maxVoltage, form.steadyTime, form.voltageRange];
+      break;
+    case "coldStorageVariables":
+      marker = ['{dwellTemp}', '{dwellTime}'];
+      fieldName = [form.dwellTemp, form.dwellTime];
+      break;
+    case "hotStorageVariables":
+      marker = ['{dwellTemp}', '{dwellTime}'];
+      fieldName = [form.dwellTemp, form.dwellTime];
+      break;
+    /* case "enduranceVibrationVariables": 
+      marker = [];
+      fieldName = [];
+      break; */
+    case "thermalShockVariables":
+      marker = ['{minTemp}', '{maxTemp}', '{dwellTime}', '{shockEvents}'];
+      fieldName = [form.minTemp, form.maxTemp, form.dwellTime, form.shockEvents];  
+      break;
+  }
+  var body = DocumentApp.getActiveDocument().getBody();
+  var footer = DocumentApp.getActiveDocument().getFooter();
+  for (i=0; i<marker.length; ++i)
+  {
+    if (fieldName[i] != "")
+    {
+      body.replaceText(marker[i], fieldName[i]); // First argument is the location in the document, second argument is the matching text field on the sidebar.
+      //footer.replaceText(marker[i], fieldName[i]); // TO DO: The footer text isn't being replaced for some reason.
+    }
+  }
+  console.log("We finished the function!");
+}
+
+function addNewTest(form)
+{
   var selectedTest = form.tests;
-  switch (selectedTest) {
+  switch (selectedTest)
+  {
     case "thermalCycle":
       appendTest('https://docs.google.com/document/d/1WZLUd_iRxE5uwvMsFIBV-DMvpGlWa8-tbdAg0QIYTo0/edit');
-      // Get test specific information from the user.
-      var tcVariables = ['{tcMinTemp}', '{tcDwellTime}', '{tcMaxTemp}', '{tcCycles}'];
       break;
     case "chemicalExposure":
       appendTest('https://docs.google.com/document/d/1Tkp-byLQ9MUcBLqyPPTP568x8rad4QcgQ9cEkV1CFk8/edit');
@@ -82,7 +136,8 @@ function addNewTest(form) {
   }
 }
 
-function appendTest(testID) {
+function appendTest(testID)
+{
   var thisDoc = DocumentApp.getActiveDocument();
   var thisBody = thisDoc.getBody();
   var templateDoc = DocumentApp.openByUrl(testID); // Pass in id of doc to be used as a template.
@@ -107,9 +162,4 @@ function appendTest(testID) {
     }
   }
   return thisDoc;
-}
-
-function getTestSpecificInformation()
-{
-
 }

--- a/Code.js
+++ b/Code.js
@@ -44,45 +44,45 @@ function populateGeneralInformation(form)
   }
 }
 
+function getTestNameAsString(test)
+{
+  var testNameAsString = test;
+  console.log(testNameAsString);
+}
+
 function populateTestSpecificInformation(form)
 {
-  console.log("form's type is " + typeof form); // Debugs as object, which matches populateGeneralInformation.
-  console.log("form.id returns: " + form.id); // Debugs as undefined. How can we get the id of the form?
-  console.log("for test specific information, form is " + form); // Debugs as [object Object]. Tried setting a case to [object Object] but got an error.
-  console.log("dwellTemp is " + form.dwellTemp + " and dwell time is " + form.dwellTime); // Debugs the typed value!!! 
+  // var storedValue = JSON.stringify(form); // Tested what JSON.stringify outputs. Could be useful in other situations.
   var marker = [];
   var fieldName = [];
-  /* TO DO: Right now the argument (the id) is being passed as a string. This causes the if statement error because the string isn't an object, so it
-  can't access the object's text boxes. Get the form's id as an object, 
-  then we can make cases for each form id that accept objects instead of strings. Can we convert the argument from string to object after it is passed in? */
-  switch (form)
+  switch (form.hiddenTestName)
   {
-    case "thermalCycleVariables":
+    case "5": /*"thermalCycleVariables"*/
       console.log("thermal cycle has been hit.")
       marker = ['{minTemp}', '{maxTemp}', '{dwellTime}', '{cycles}'];
       fieldName = [form.minTemp, form.maxTemp, form.dwellTime, form.cycles]; 
       break;
-    case "coldSoakVariables":
+    case "1": /* "coldSoakVariables" */
       marker = ['{dwellTemp}', '{dwellTime}', '{minVoltage}', '{maxVoltage}'];
       fieldName = [form.dwellTemp, form.dwellTime, form.minVoltage, form.maxVoltage];
       break;
-    case "hotSoakVariables":
+    case "2": /*"hotSoakVariables" */
       marker = ['{dwellTemp}', '{dwellTime}', '{minVoltage}', '{maxVoltage}', '{steadyTime}', '{voltageRange}'];
       fieldName = [form.dwellTemp, form.dwellTime, form.minVoltage, form.maxVoltage, form.steadyTime, form.voltageRange];
       break;
-    case "coldStorageVariables":
+    case "4": /*"coldStorageVariables"*/
       marker = ['{dwellTemp}', '{dwellTime}'];
       fieldName = [form.dwellTemp, form.dwellTime];
       break;
-    case "hotStorageVariables":
+    case "3": /*"hotStorageVariables"*/
       marker = ['{dwellTemp}', '{dwellTime}'];
       fieldName = [form.dwellTemp, form.dwellTime];
       break;
-    /* case "enduranceVibrationVariables": 
+    case "7": /*"enduranceVibrationVariables"*/ // TO DO: Add appropriate links to the HTML form for this test.
       marker = [];
       fieldName = [];
-      break; */
-    case "thermalShockVariables":
+      break;
+    case "6": /*"thermalShockVariables"*/
       marker = ['{minTemp}', '{maxTemp}', '{dwellTime}', '{shockEvents}'];
       fieldName = [form.minTemp, form.maxTemp, form.dwellTime, form.shockEvents];  
       break;
@@ -97,7 +97,6 @@ function populateTestSpecificInformation(form)
       //footer.replaceText(marker[i], fieldName[i]); // TO DO: The footer text isn't being replaced for some reason.
     }
   }
-  console.log("We finished the function!");
 }
 
 function addNewTest(form)

--- a/Tests.html
+++ b/Tests.html
@@ -109,16 +109,29 @@ margin-top: 10px;
     <p>What vibration profile do you want to use?</p>
     <!-- <input type="text" name="minTemp" value=""> -->
   </form>
-  <input type="button" class="action testInfoButton" onclick="" value="Submit information for this test" /> 
+  <input type="button" class="action testInfoButton" onclick="submitSpecificTestInformation()" value="Submit information for this test" /> 
   </body>
   
   <script type="text/javascript">
   function formSubmit()
   {
-    var temp = document.forms[0].tests.value + "Variables";
-    document.getElementById(temp).style.display = 'block';
+    var selectedTest = document.forms[0].tests.value + "Variables"; // Tells us what test was selected from the drop-down.
+    document.getElementById(selectedTest).style.display = 'block';
     document.querySelector('.testInfoButton').style.display = 'block';
-    google.script.run.addNewTest(document.forms[0]); // I believe the argument uses the first form in the HTML.
-   }
+    google.script.run.addNewTest(document.forms[0]);
+  }
+
+  function submitSpecificTestInformation()
+  {
+    formNames = new Map([["coldSoakVariables", 1],["hotSoakVariables", 2],["hotStorageVariables", 3],
+    ["coldStorageVariables", 4],["thermalCycleVariables", 5],["thermalShockVariables", 6],
+    ["enduranceVibrationVariables", 7]]);
+
+    var selectedTest = document.forms[0].tests.value + "Variables"; //
+    alert(selectedTest);
+    var index = formNames.get(selectedTest);  //Look up in map to get form index.
+    alert(index);
+    google.script.run.populateTestSpecificInformation(document.forms[3]) //A form goes in here...
+  }
   </script>
 </html>

--- a/Tests.html
+++ b/Tests.html
@@ -52,6 +52,7 @@ margin-top: 10px;
     <input type="text" name="minVoltage" value="">
     <p>What's the maximum voltage?</p>
     <input type="text" name="maxVoltage" value="">
+    <input type="hidden" name="hiddenTestName" value = "1"/> <!--Since form.id only returns undefined in Code.js, this hidden input is how to tell what form we're in-->
   </form>
   <form id="hotSoakVariables" class="toggleForm"> 
     <p>Tell me more about this hot soak test:</p>
@@ -67,6 +68,7 @@ margin-top: 10px;
     <input type="text" name="steadyTime" value="">
     <p>What's the voltage range?</p>
     <input type="text" name="voltageRange" value="">
+    <input type="hidden" name="hiddenTestName" value = "2"/>
   </form>
   <form id="hotStorageVariables" class="toggleForm"> 
     <p>Tell me more about this hot storage test:</p>
@@ -74,6 +76,7 @@ margin-top: 10px;
     <input type="text" name="dwellTemp" value="">
     <p>How long is the dwell time in hours?</p>
     <input type="text" name="dwellTime" value="">
+    <input type="hidden" name="hiddenTestName" value = "3"/>
   </form>
   <form id="coldStorageVariables" class="toggleForm"> 
     <p>Tell me more about this cold storage test:</p>
@@ -81,6 +84,7 @@ margin-top: 10px;
     <input type="text" name="dwellTemp" value="">
     <p>How long is the dwell time in hours?</p>
     <input type="text" name="dwellTime" value="">
+    <input type="hidden" name="hiddenTestName" value = "4"/>
   </form>
   <form id="thermalCycleVariables" class="toggleForm">
     <p>Tell me more about this thermal cycling test:</p>
@@ -91,7 +95,8 @@ margin-top: 10px;
     <p>How long is the dwell time in hours? (Look at the table in the overview.)</p>
     <input type="text" name="dwellTime" value="">
     <p>How many cycles are there?</p>
-    <input type="text" name="cycles" value=""> 
+    <input type="text" name="cycles" value="">
+    <input type="hidden" name="hiddenTestName" value = "5"/> 
   </form>
   <form id="thermalShockVariables" class="toggleForm">
     <p>Tell me more about this thermal shock test:</p>
@@ -102,12 +107,14 @@ margin-top: 10px;
     <p>How long is the dwell time in hours?</p>
     <input type="text" name="dwellTime" value="">
     <p>How many shock events are there?</p>
-    <input type="text" name="shockEvents" value=""> 
+    <input type="text" name="shockEvents" value="">
+    <input type="hidden" name="hiddenTestName" value = "6"/> 
   </form>
   <form id="enduranceVibrationVariables" class="toggleForm"> <!--TO DO: Add bulleted list that insert the different profiles -->
     <p>Tell me more about this endurance (survivability) vibration test:</p>
     <p>What vibration profile do you want to use?</p>
     <!-- <input type="text" name="minTemp" value=""> -->
+    <input type="hidden" name="hiddenTestName" value = "7"/>
   </form>
   <input type="button" class="action testInfoButton" onclick="submitSpecificTestInformation()" value="Submit information for this test" /> 
   </body>
@@ -129,10 +136,8 @@ margin-top: 10px;
 
     var selectedTest = document.forms[0].tests.value + "Variables";
     var index = formNames.get(selectedTest);  // Looks up the test in the map to get the form index.
-    alert("The id is " + document.forms[index].id);
-    google.script.run.populateTestSpecificInformation(document.forms[index]) // A form goes in here...
-    // google.script.run.populateTestSpecificInformation(document.forms[index].id) // Testing what happens with a .id in the argument.
-    alert("Ran the script.");
+    var testNameAsString = document.forms[index].id;
+    google.script.run.populateTestSpecificInformation(document.forms[index]) // A form goes in here.
   }
   </script>
 </html>

--- a/Tests.html
+++ b/Tests.html
@@ -123,15 +123,16 @@ margin-top: 10px;
 
   function submitSpecificTestInformation()
   {
-    formNames = new Map([["coldSoakVariables", 1],["hotSoakVariables", 2],["hotStorageVariables", 3],
+    var formNames = new Map([["coldSoakVariables", 1],["hotSoakVariables", 2],["hotStorageVariables", 3],
     ["coldStorageVariables", 4],["thermalCycleVariables", 5],["thermalShockVariables", 6],
     ["enduranceVibrationVariables", 7]]);
 
-    var selectedTest = document.forms[0].tests.value + "Variables"; //
-    alert(selectedTest);
-    var index = formNames.get(selectedTest);  //Look up in map to get form index.
-    alert(index);
-    google.script.run.populateTestSpecificInformation(document.forms[3]) //A form goes in here...
+    var selectedTest = document.forms[0].tests.value + "Variables";
+    var index = formNames.get(selectedTest);  // Looks up the test in the map to get the form index.
+    alert("The id is " + document.forms[index].id);
+    google.script.run.populateTestSpecificInformation(document.forms[index]) // A form goes in here...
+    // google.script.run.populateTestSpecificInformation(document.forms[index].id) // Testing what happens with a .id in the argument.
+    alert("Ran the script.");
   }
   </script>
 </html>


### PR DESCRIPTION
I was able to get the user's values for form.dwellTemp and form.dwellTime when debugging by adding those lines as debug code within populateTestSpecificInformation(), where the function is being passed the form as an object.

I also experimented with passing populateTestSpecificInformation() the form as a string: 
`   // google.script.run.populateTestSpecificInformation(document.forms[index]) // This passes an object as the argument.
    google.script.run.populateTestSpecificInformation(document.forms[index].id) // Testing what happens when you add .id, which passes a string as the argument.` 
Passing a string caused the switch to run, but the if statement for replacing text wouldn't run because the function was never passed the form as an object, just the form as a string, meaning that in this scenario, form elements like form.dwellTemp can't be accessed.

We need to get the form as an object as well as the form's id as a string. To do this, I tried modifying populateTestSpecificInformation() to accept two inputs, like this:
`google.script.run.populateTestSpecificInformation(document.forms[index], document.forms[index].id) // First argument is the form as an object, the second argument is the form id as a string.`
However, populateTestSpecificInformation() wouldn't run at all after I made this change. I'm not sure why, because the function runs when I pass only one of those inputs, so one would assume that I could pass both of them at the same time. I'm looking into alternative ways I can get the form id.